### PR TITLE
Update cloud9-postgresql-rails-howto.md

### DIFF
--- a/cloud9-postgresql-rails-howto.md
+++ b/cloud9-postgresql-rails-howto.md
@@ -1,76 +1,79 @@
-# How to setup PostgreSQL & Rails on Cloud9
+- Ruby and Rail editions:
+Ruby version : 2.3.1
+Rails version : rails', '~> 5.0.0', '>= 5.0.0.1'
 
-At time of writing, Cloud9 has PostgreSQL pre-installed, so you won't need to install it yourself. However, its not running by default, so you will need to start it with this command in the terminal:
+- Cloning application from Git repository:
+# git clone https://github.com/CMPT-276-assignment/whatshoudieat.git
 
-sudo service postgresql start
+- How to setup PostgreSQL & Rails on Cloud9:
+At the time of writing, Cloud9 has PostgreSQL pre-installed, so you will not need to install it yourself. However, it is not running by default, so you will need to type this command in the terminal:
+# sudo service postgresql start
 
 Change the PostgreSQL password to 'password' (or choose a different password):
+# sudo sudo -u postgres psql
 
-sudo sudo -u postgres psql
+This will open the psql client.
+Type \password and press enter to begin the process of changing the password:
+# postgres=# \password
 
-# This will open the psql client.
+Type your new password (e.g. "password") and press enter twice:
+# Enter new password: 
+# Enter it again: 
 
-# Type \password and press enter to begin process
-# of changing the password:
-postgres=# \password
-
-# Type your new password (e.g. "password") and press enter twice:
-Enter new password: 
-Enter it again: 
-
-# Password changed, quit psql with \q
-postgres=# \q 
+Password changed, quit psql with \q
+# postgres=# \q 
 
 Edit your `config/database.yml` to be:
-
-default: &default
-  adapter: postgresql
-  encoding: unicode
-  pool: 5
+# default: &default
+#   adapter: postgresql
+#   encoding: unicode
+#   pool: 5
   
-  # Important configs for cloud9, change password value
-  # to what you entered in the previous psql step.
-  template: template0
-  username: ubuntu
-  password: password
+Important configs for cloud9, change password value to what you entered in the previous psql step.
+# template: template0
+# username: ubuntu
+# password: password
   
-development:
-  <<: *default
-  database: your_app_name_development
+# development:
+#   <<: *default
+#   database: your_app_name_development
 
-test:
-  <<: *default
-  database: your_app_name_test
+# test:
+#   <<: *default
+#   database: your_app_name_test
 
-production:
-  <<: *default
-  database: your_app_name_production
-  username: your_app_name
-  password: <%= ENV['YOUR_APP_NAME_DATABASE_PASSWORD'] %>
+# production:
+#   <<: *default
+#   database: your_app_name_production
+#   username: your_app_name
+#   password: <%= ENV['YOUR_APP_NAME_DATABASE_PASSWORD'] %>
 
 
-(Note the `template`, `username`, and `password` configs in the `default` section above are essential).
+(Note that the `template`, `username`, and `password` configs in the `default` sections above are essential).
 
 Add the `pg` gem to your `Gemfile`:
+# gem 'pg'
+# gem 'therubyracer'
 
-gem 'pg'
+Set up database:
+# bundle install
+# bundle exec rake db:setup
+# rake db:create
+# rake db:migrate
 
-Run `bundle install`.
 
+This is for installing image magic widget (plugin for uploading image):
+# sudo apt-get update
+# sudo apt-get install imagemagick
 
+To see all db-related taks:
+# bin/rake -AD db 
 
-bundle exec rake db:setup
+- Setup reCAPCHA
+Add the 'gem 'recaptcha' to your 'Gemfile'
+# gem 'recaptcha', require: 'recaptcha/rails'
 
-rake db:create
-
-rake db:migrate
-
-# THis is for installing image magic widget
-sudo apt-get update
-sudo apt-get install imagemagick
-
-# Run bin/rake -AD db to see all db-related tasks
-
-# THis is for installing image magic widget
-sudo apt-get update
-sudo apt-get install imagemagick
+Access link https://www.google.com/recaptcha/admin#list 
+Choose reCAPCHA v2
+Enter the domain of the app deployed in Heroku and accept the agrrement term to get the keys.
+In the file 'recapcha.rb' (whatshoudieat/config/initializers/recapcha.rb), place the site key and secret key for use.


### PR DESCRIPTION
There are a few noticeable grammar/spelling errors in the document.
A redundancy issue arises when the section "This is for installing image magic widget" was repeated twice.
A lot of unnecessary white-space.
Inserting point-form and highlight important commands.  
Adding versions of Ruby and Rails to eliminate any conflicts among the incompatible tools.
Deleting the command "bundle exec rake db:setup".
Installing JavaScript run-time environment to proceed "rake db:create".
Including instructions for setting up reCAPCHA.
  